### PR TITLE
Boundaryでスタイルが当たらない

### DIFF
--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,0 +1,20 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+import { useCatch } from "remix";
+
+export const loader = () => {
+  throw new Response('', { status: 404 })
+}
+
+export default () => {
+  return null
+}
+
+export function CatchBoundary() {
+  const caught = useCatch();
+  return (
+    <div css={css`color: red;`}>
+      <h1>{caught.statusText}</h1>
+    </div>
+  )
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -35,7 +35,7 @@ export default function Index() {
     <div>
       <header>
         <Link to="/">Top Page</Link> | <Link to="/sub">Sub Page</Link> |{" "}
-        <Link to="/４０４">NotFound Page</Link>
+        <Link to="/404">NotFound Page</Link>
       </header>
       <div css={wrapperStyle}>
         <h1 css={state ? headingStyle : headingDefaultStyle}>


### PR DESCRIPTION
## 事象
- root.tsx の CatchBoundary と ErrorBoundary でコンポネントを返すとなぜかemotionのスタイルが当たらない
- root.tsx 以外のルートファイルのBoundaryでエラーをキャッチした場合は、スタイルが適応される

## 解決策
もう少し時間をかけて調査すれば、根本原因に辿り着けそうな気がするが、一旦別の方法で対処する

- catch all route (`$.tsx`) を設置して、not found なアクセスをそちらで受ける
    - https://remix.run/docs/en/v1/api/conventions#splat-routes
- 全角文字パスだと catch all route path で受けることができないようなので、/４０４ を /404に変更
    - おそらく、remix-run側のルーティングを処理するための正規表現に全角文字が含まれていないと思われる。 
    - そもそも全角文字パスはcatch all routeに限らずRemixと相性が悪そう。